### PR TITLE
Added further Ag standards to standards.ini

### DIFF
--- a/lib/Demeter/share/standards/standards.ini
+++ b/lib/Demeter/share/standards/standards.ini
@@ -777,6 +777,118 @@ record       = 4
 xanes        = 25513.34, 25514, 25520.45, 25552.57
 deriv        = 25513.34, 25538.93
 
+[Ag sulfate]
+element      = ag
+tag          = Silver sulfate
+comment      = Silver sulfate
+location     = APS 20BM
+people       = Maggy Lenke, Gordon Southam, BR
+date         = 7/1/2006
+crystal      = Si(111)
+edge         = K
+file         = %share%/standards/data/Ag.prj
+record       = 6
+xanes        = 25512.8, 25520.1, 25558
+deriv        = 25512.8, 25549.1
+
+[Ag sulfite]
+element      = ag
+tag          = Silver sulfite
+comment      = Silver sulfite
+location     = APS 20BM
+people       = Maggy Lenke, Gordon Southam, BR
+date         = 7/1/2006
+crystal      = Si(111)
+edge         = K
+file         = %share%/standards/data/Ag.prj
+record       = 8
+xanes        = 25513.9, 25520, 25557.8
+deriv        = 25513.9, 25549.2
+
+[Ag sulfide]
+element      = ag
+tag          = Silver sulfide
+comment      = Silver sulfide
+location     = APS 20BM
+people       = Maggy Lenke, Gordon Southam, BR
+date         = 7/1/2006
+crystal      = Si(111)
+edge         = K
+file         = %share%/standards/data/Ag.prj
+record       = 10
+xanes        = 25513.2, 25525, 25540.5, 25572.5
+deriv        = 25513.2, 25532.7, 25562
+
+[Ag chloride]
+element      = ag
+tag          = Silver chloride
+comment      = Silver chloride
+location     = APS 20BM
+people       = Maggy Lenke, Gordon Southam, BR
+date         = 7/1/2006
+crystal      = Si(111)
+edge         = K
+file         = %share%/standards/data/Ag.prj
+record       = 12
+xanes        = 25513.3, 25518.8, 25534.1, 25565.4
+deriv        = 25513.3, 25530, 25547.2, 25560.3, 25592.7
+
+[Ag oxide]
+element      = ag
+tag          = Silver oxide
+comment      = Silver oxide
+location     = APS 20BM
+people       = Maggy Lenke, Gordon Southam, BR
+date         = 7/1/2006
+crystal      = Si(111)
+edge         = K
+file         = %share%/standards/data/Ag.prj
+record       = 14
+xanes        = 25512.5, 25526.5, 25537.1, 25567.7, 25590.5
+deriv        = 25512.5, 25534.5, 25557.7, 25581.3
+
+[Ag K cyanide]
+element      = ag
+tag          = Silver pottasium cyanide
+comment      = Silver pottasium cyanide
+location     = APS 20BM
+people       = Maggy Lenke, Gordon Southam, BR
+date         = 7/1/2006
+crystal      = Si(111)
+edge         = K
+file         = %share%/standards/data/Ag.prj
+record       = 16
+xanes        = 25512, 25527.6, 25545.7, 25591.1 
+deriv        = 25512, 25519.6, 25538.3, 25577.6
+
+[Ag cyanide]
+element      = ag
+tag          = Silver cyanide
+comment      = Silver cyanide
+location     = APS 20BM
+people       = Maggy Lenke, Gordon Southam, BR
+date         = 7/1/2006
+crystal      = Si(111)
+edge         = K
+file         = %share%/standards/data/Ag.prj
+record       = 18
+xanes        = 25512.5, 25526.2, 25579
+deriv        = 25512.5, 25536.6, 25558.2
+
+[Ag phosphate]
+element      = ag
+tag          = Silver phosphate
+comment      = Silver phosphate
+location     = APS 20BM
+people       = Maggy Lenke, Gordon Southam, BR
+date         = 7/1/2006
+crystal      = Si(111)
+edge         = K
+file         = %share%/standards/data/Ag.prj
+record       = 20
+xanes        = 25514.1, 25521.4, 25560.2
+deriv        = 25514.1, 25530.8, 25548.6
+
 ##############################################################################################
 ## Cd standards project file 48
 


### PR DESCRIPTION
Added standards from ag.prj that were missing from standards.ini. Edge
and peak locations were determined as the point where the
derivative/second derivative (as appropriate) intersected x. Judging
from the dataset titles I'm assuming they were all recorded by Lenke et
al.  at the APS.