### PR TITLE
Add support for access control lists

### DIFF
--- a/lib/Demeter/Tools.pm
+++ b/lib/Demeter/Tools.pm
@@ -30,6 +30,7 @@ use DateTime;
 use Data::Dumper;
 use Text::Wrap;
 use File::Touch;
+use filetest 'access';
 #use Memoize;
 #memoize('distance');
 


### PR DESCRIPTION
Hi Bruce,

We faced a problem here opening certain files over our network: an error message popped up saying they were not readable.
I traced back the origins of the issue to the files' access control lists. Using the suggestion from http://perldoc.perl.org/functions/-X.html I implemented a fix which seems to work fine.

Best,

Tom

