### PR TITLE
User-specific larch_server daemons

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -93,6 +93,7 @@ my $build = DemeterBuilder
 				'Math::Round'		    => '0',
 				'Math::Spline'		    => '0',
 				'Pod::POM'                  => '0',
+				'Proc::ProcessTable'        => '0',
 				'Const::Fast'		    => '0.01',
 				'Regexp::Common'	    => '0',
 				'Regexp::Assemble'	    => '0',

--- a/bin/dartemis
+++ b/bin/dartemis
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 BEGIN {
   # turn off Unity feature of the Mac-like global menu bar, which
   # interacts really poorly with Wx.  See

--- a/bin/dathena
+++ b/bin/dathena
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 BEGIN {
   # turn off Unity feature of the Mac-like global menu bar, which
   # interacts really poorly with Wx.  See

--- a/bin/datoms
+++ b/bin/datoms
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 =for Copyright
  .

--- a/bin/denergy
+++ b/bin/denergy
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/bin/denv
+++ b/bin/denv
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 =for Copyright
  .

--- a/bin/dfeff
+++ b/bin/dfeff
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 =for Copyright
  .

--- a/bin/dfeffit
+++ b/bin/dfeffit
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 =for Copyright
  .

--- a/bin/dhephaestus
+++ b/bin/dhephaestus
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 BEGIN {
   # turn off Unity feature of the Mac-like global menu bar, which
   # interacts really poorly with Wx.  See

--- a/bin/dlsprj
+++ b/bin/dlsprj
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 =for Copyright
  .

--- a/bin/intrp
+++ b/bin/intrp
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 =for Copyright
  .

--- a/bin/lartemis
+++ b/bin/lartemis
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 BEGIN {
   # turn off Unity feature of the Mac-like global menu bar, which
   # interacts really poorly with Wx.  See

--- a/bin/lathena
+++ b/bin/lathena
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 BEGIN {
   # turn off Unity feature of the Mac-like global menu bar, which
   # interacts really poorly with Wx.  See

--- a/bin/lhephaestus
+++ b/bin/lhephaestus
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 BEGIN {
   # turn off Unity feature of the Mac-like global menu bar, which
   # interacts really poorly with Wx.  See

--- a/bin/prj2json
+++ b/bin/prj2json
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 =for Copyright
  .

--- a/bin/rdfit
+++ b/bin/rdfit
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use Demeter qw(:ui=screen);
 use Getopt::Long;

--- a/bin/standards
+++ b/bin/standards
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (c) 2008-2016 Bruce Ravel (L<http://bruceravel.github.io/home>). All rights reserved.
 #


### PR DESCRIPTION
Hi @bruceravel @newville 

Sorry for the delay: I was on holidays last week.

I think I have come up with a solution for #29, at least for Linux and Mac OS X.

Basically the code will now check for running larch daemons, check who the owner is and which port they are using.

If the current user already has a daemon running, then that one will be used.
Otherwise, a new larch_server will be spawned with a port number that is not currently being used by any of the running larch daemons. This new port number will be greater than or equal tho 4966.

Now the only problem is that this won't work on Windows because ProcessTable doesn't return the command-line arguments that were used to execute the larch daemons... This [Perl package](http://search.cpan.org/~kxj/Win32-Process-CommandLine-0.03/lib/Win32/Process/CommandLine.pm) looks like it could be useful here, but I do not have a Windows environment to test this on.

PS: please forgive me my embarrassing Perl coding...

