### PR TITLE
better enable Larch on Windows 

### DIFF
--- a/DemeterBuilder.pm
+++ b/DemeterBuilder.pm
@@ -34,8 +34,8 @@ use File::Which qw(which);
 
 my $WINPERL = File::Spec->catfile($ENV{APPDATA}, 'DemeterPerl');
 my %windows = (base    => $WINPERL,  # base of Demeter's perl
-	       gnuwin  => File::Spec->catfile($WINPERL, 'lib'),  
-	       mingw   => File::Spec->catfile($WINPERL, 'c', 'lib', 'i686-w64-mingw32', '4.7.3'), 
+	       gnuwin  => File::Spec->catfile($WINPERL, 'lib'),
+	       mingw   => File::Spec->catfile($WINPERL, 'c', 'lib', 'i686-w64-mingw32', '4.7.3'),
 	       pgplot  => File::Spec->catfile($WINPERL, 'c', 'lib', 'pgplot'),
 	       ifeffit => File::Spec->catfile($WINPERL, 'c', 'lib'),
 	       gnuplot => File::Spec->catfile($WINPERL, 'c', 'bin', 'gnuplot', 'bin'),
@@ -169,43 +169,44 @@ sub ACTION_test_for_larchserver {
   print STDOUT "Looking for Python and Larch ---> ";
   my $pyexe  = '';
   my $larchexe = '';
-  my @dirlist = split /;/, $ENV{'PATH'};
   if (($^O eq 'MSWin32') or ($^O eq 'cygwin')) {
-      push @dirlist,  (File::Spec->catfile($ENV{APPDATA}, 'Continuum', 'Anaconda3'),
-		       File::Spec->catfile($ENV{APPDATA}, 'Continuum', 'Anaconda2'),
-		       File::Spec->catfile($ENV{APPDATA}, 'Continuum', 'Anaconda'),
-		       File::Spec->catfile($ENV{LOCALAPPDATA}, 'Continuum', 'Anaconda3'),
-		       File::Spec->catfile($ENV{LOCALAPPDATA}, 'Continuum', 'Anaconda2'),
-		       File::Spec->catfile($ENV{LOCALAPPDATA}, 'Continuum', 'Anaconda'));
+    my @dirlist = split /;/, $ENV{'PATH'};
+    push @dirlist,  (File::Spec->catfile($ENV{LOCALAPPDATA}, 'Continuum', 'Anaconda3'),
+		     File::Spec->catfile($ENV{LOCALAPPDATA}, 'Continuum', 'Anaconda2'),
+		     File::Spec->catfile($ENV{LOCALAPPDATA}, 'Continuum', 'Anaconda'),
+		     File::Spec->catfile($ENV{APPDATA}, 'Continuum', 'Anaconda3'),
+		     File::Spec->catfile($ENV{APPDATA}, 'Continuum', 'Anaconda2'),
+		     File::Spec->catfile($ENV{APPDATA}, 'Continuum', 'Anaconda'));
 
       foreach my $d (@dirlist) {
 	  my $pyexe_ =  File::Spec->catfile($d, 'python.exe');
 	  my $larch_ =  File::Spec->catfile($d, 'Scripts', 'larch_server');
-	  if ((-e $pyexe_) && (-e $larch_))  { 
+	  if ((-e $pyexe_) && (-e $larch_))  {
 	      $larchexe = $larch_,
 	      $pyexe = $pyexe_;
 	      last;
 	  }
       }
   } else {
-      push @dirlist,  (File::Spec->catfile($ENV{HOME}, 'anaconda3'),
-		       File::Spec->catfile($ENV{HOME}, 'anaconda2'),
-		       File::Spec->catfile($ENV{HOME}, 'anaconda'));
+    my @dirlist = split /:/, $ENV{'PATH'};
+    push @dirlist,  (File::Spec->catfile($ENV{HOME}, 'anaconda3', 'bin'),
+		     File::Spec->catfile($ENV{HOME}, 'anaconda2', 'bin'),
+		     File::Spec->catfile($ENV{HOME}, 'anaconda', 'bin'));
 
-      foreach my $d (@dirlist) {
-	  my $pyexe_ =  File::Spec->catfile($d, 'python');
-	  my $larch_ =  File::Spec->catfile($d, 'larch_server');
-	  if ((-e $pyexe_) && (-e $larch_))  { 
-	      $larchexe = $larch_,
-	      $pyexe = $pyexe_;
-	      last;
-	  }
+    foreach my $d (@dirlist) {
+      my $pyexe_ =  File::Spec->catfile($d, 'python');
+      my $larch_ =  File::Spec->catfile($d, 'larch_server');
+      if ((-e $pyexe_) && (-e $larch_))  {
+	$larchexe = $larch_,
+	  $pyexe = $pyexe_;
+	last;
       }
+    }
   }
-  if ($larchexe != '') { 
+  if ($larchexe eq '') {
       print "not found\n";
   } else {
-      print "found\n";
+      print "found  $pyexe  // $larchexe \n";
   }
   my $larch_server_ini_text = <<"END_OF_FILE";
 ---
@@ -246,7 +247,7 @@ sub ACTION_compile_ifeffit_wrapper {
 
 		       q{-L}.$windows{base}.q{\perl\lib\CORE"},
 		       q{-L}.$windows{base}.q{\c\lib"},
-		       q{-L}.$windows{mingw}, 
+		       q{-L}.$windows{mingw},
 		       q{-L}.$windows{ifeffit},
 		       q{-lifeffit -lxafs},
 

--- a/DemeterBuilder.pm
+++ b/DemeterBuilder.pm
@@ -32,18 +32,14 @@ use File::Which qw(which);
 ######################################################################
 ## Configuration
 
-my %windows = (strawberry => 'C:\strawberry',                     # base of Strawberry perl
-	       #gnuwin     => 'C:\GnuWin32',                      # base of GnuWin32, readline, ncurses
-	       gnuwin     => 'C:\strawberry\lib',
-	       #mingw      => 'C:\MinGW',                         # base of the MinGW compiler suite
-	       mingw      => 'C:\strawberry\c\lib\gcc\i686-w64-mingw32\4.4.3',
-	       #pgplot     => 'C:\MinGW\lib\pgplot',              # install location of GRwin and PGPLOT
-	       pgplot     => 'C:\strawberry\c\lib\pgplot',
-	       #ifeffit    => 'C:\source\ifeffit-1.2.11d\src\lib', # install location of libifeffit.a
-	       ifeffit    => 'C:\strawberry\lib',
-	       #gnuplot    => 'C:\gnuplot\binaries',		  # install location of gnuplot.exe
-	       gnuplot    => 'C:\strawberry\c\bin',
-	       artug      => 'C:\strawberry\c\perl\site\lib\Demeter\share',
+my $WINPERL = File::Spec->catfile($ENV{APPDATA}, 'DemeterPerl');
+my %windows = (base    => $WINPERL,  # base of Demeter's perl
+	       gnuwin  => File::Spec->catfile($WINPERL, 'lib'),  
+	       mingw   => File::Spec->catfile($WINPERL, 'c', 'lib', 'i686-w64-mingw32', '4.7.3'), 
+	       pgplot  => File::Spec->catfile($WINPERL, 'c', 'lib', 'pgplot'),
+	       ifeffit => File::Spec->catfile($WINPERL, 'c', 'lib'),
+	       gnuplot => File::Spec->catfile($WINPERL, 'c', 'bin', 'gnuplot', 'bin'),
+	       artug   => File::Spec->catfile($WINPERL, 'perl', 'site', 'lib', 'Demeter', 'share'),
 	      );
 our $ghpages = '../demeter-gh-pages';
 
@@ -187,15 +183,14 @@ sub ACTION_compile_ifeffit_wrapper {
 		       q{-L}.$windows{gnuwin}.q{\lib"},
 		       q{-lcurses -lreadline},
 
-		       q{-L}.$windows{strawberry}.q{\perl\lib\CORE"},
-		       q{-L}.$windows{strawberry}.q{\c\lib"},
-		       q{-L}.$windows{strawberry}.q{\c\lib\gcc\i686-w64-mingw32\4.4.3"},
-
+		       q{-L}.$windows{base}.q{\perl\lib\CORE"},
+		       q{-L}.$windows{base}.q{\c\lib"},
+		       q{-L}.$windows{mingw}, 
 		       q{-L}.$windows{ifeffit},
 		       q{-lifeffit -lxafs},
 
 		       #q{-L"C:\MinGW\bin"},
-		       q{-L}.$windows{mingw}.q{\lib\gcc\mingw32\4.5.2"},
+		       q{-L}.$windows{mingw},
 		       q{-L}.$windows{mingw}.q{\lib"},
 		       q(-lgfortran -lmingw32 -lgcc_s -lmoldname -lmingwex -lmsvcrt -luser32 -lkernel32 -ladvapi32 -lshell32),
 

--- a/lib/Larch.pm
+++ b/lib/Larch.pm
@@ -26,6 +26,7 @@ $rhash->{quiet}   ||= 0;
 $rhash->{exe}       = (($^O eq 'MSWin32') or ($^O eq 'cygwin')) ? $rhash->{windows} : 'larch_server';
 
 my $command = $rhash->{quiet} ? $rhash->{exe}." -q start" : $rhash->{exe}." start";
+print "Trying Larch server:\n#  $command\n";
 my $ok = system $command;
 
 


### PR DESCRIPTION
This PR allows better auto-launching of Larch + Demeter on Windows. 

Basically, the larch_server.ini script is written at build time, in the subroutine `ACTION_test_for_larchserver()` in `DemeterBuilder.pm`.   This searches the PATH environment + expected directories for Anaconda python for a consistent set of "python executable" and "larch_server script",  stopping at the first set found.   The code could probably be more idiomatic or modern Perl -- 

With this change, Athena+Larch works for me on Windows. Though I've only done minimal testing, I found no problems.   I have not yet re-tested on Linux, but believe there should be no problems introduced there.

Mac OSX is giving trouble with frequent long (multiple seconds) delays in the data processing, seemingly at random points in the process.   I  think this may be related to GUI code not XML-RPC, but I'm not certain of this, and am still investigating. 

