### PR TITLE
More improvements to starting Larch server

### DIFF
--- a/DemeterBuilder.pm
+++ b/DemeterBuilder.pm
@@ -167,46 +167,43 @@ sub ACTION_test_for_larchserver {
   # search for Python exe and Larch server script, write larch_server.ini
   my $inifile = File::Spec->catfile(cwd, 'lib', 'Demeter', 'share', 'ini', 'larch_server.ini');
   print STDOUT "Looking for Python and Larch ---> ";
-  my $pyexe  = '';
-  my $larchexe = '';
+  my $larchexec  = '';
   if (($^O eq 'MSWin32') or ($^O eq 'cygwin')) {
-    my @dirlist = split /;/, $ENV{'PATH'};
-    push @dirlist,  (File::Spec->catfile($ENV{LOCALAPPDATA}, 'Continuum', 'Anaconda3'),
-		     File::Spec->catfile($ENV{LOCALAPPDATA}, 'Continuum', 'Anaconda2'),
-		     File::Spec->catfile($ENV{LOCALAPPDATA}, 'Continuum', 'Anaconda'),
-		     File::Spec->catfile($ENV{APPDATA}, 'Continuum', 'Anaconda3'),
-		     File::Spec->catfile($ENV{APPDATA}, 'Continuum', 'Anaconda2'),
-		     File::Spec->catfile($ENV{APPDATA}, 'Continuum', 'Anaconda'));
-
+      my @dirlist = split /;/, $ENV{'PATH'};
+      push @dirlist,  (File::Spec->catfile($ENV{LOCALAPPDATA}, 'Continuum', 'Anaconda3'),
+		       File::Spec->catfile($ENV{LOCALAPPDATA}, 'Continuum', 'Anaconda2'),
+		       File::Spec->catfile($ENV{LOCALAPPDATA}, 'Continuum', 'Anaconda'),
+		       File::Spec->catfile($ENV{APPDATA}, 'Continuum', 'Anaconda3'),
+		       File::Spec->catfile($ENV{APPDATA}, 'Continuum', 'Anaconda2'),
+		       File::Spec->catfile($ENV{APPDATA}, 'Continuum', 'Anaconda'),
+		       'C:\Python27', 'C:\Python35');
       foreach my $d (@dirlist) {
 	  my $pyexe_ =  File::Spec->catfile($d, 'python.exe');
 	  my $larch_ =  File::Spec->catfile($d, 'Scripts', 'larch_server');
 	  if ((-e $pyexe_) && (-e $larch_))  {
-	      $larchexe = $larch_,
-	      $pyexe = $pyexe_;
+	      $larchexec = "$pyexe_ $larch_";
 	      last;
 	  }
       }
   } else {
-    my @dirlist = split /:/, $ENV{'PATH'};
-    push @dirlist,  (File::Spec->catfile($ENV{HOME}, 'anaconda3', 'bin'),
-		     File::Spec->catfile($ENV{HOME}, 'anaconda2', 'bin'),
-		     File::Spec->catfile($ENV{HOME}, 'anaconda', 'bin'));
+      my @dirlist = split /:/, $ENV{'PATH'};
+      push @dirlist,  (File::Spec->catfile($ENV{HOME}, 'anaconda3', 'bin'),
+		       File::Spec->catfile($ENV{HOME}, 'anaconda2', 'bin'),
+		       File::Spec->catfile($ENV{HOME}, 'anaconda', 'bin'));
 
-    foreach my $d (@dirlist) {
-      my $pyexe_ =  File::Spec->catfile($d, 'python');
-      my $larch_ =  File::Spec->catfile($d, 'larch_server');
-      if ((-e $pyexe_) && (-e $larch_))  {
-	$larchexe = $larch_,
-	  $pyexe = $pyexe_;
-	last;
+      foreach my $d (@dirlist) {
+	  my $pyexe_ =  File::Spec->catfile($d, 'python');
+	  my $larch_ =  File::Spec->catfile($d, 'larch_server');
+	  if ((-e $pyexe_) && (-e $larch_))  {
+	      $larchexec = "$pyexe_ $larch_";
+	      last;
+	  }
       }
-    }
   }
-  if ($larchexe eq '') {
+  if ($larchexec eq '') {
       print "not found\n";
   } else {
-      print "found  $pyexe  // $larchexe \n";
+      print "found  $larchexec \n";
   }
   my $larch_server_ini_text = <<"END_OF_FILE";
 ---
@@ -214,7 +211,7 @@ server: 'localhost' # URL of larch_server or "localhost" is running locally
 port: 4966          # the port number the larch server is listening to
 timeout: 3          # the timeout in seconds before Demeter gives up trying to talk to the larch server
 quiet: 1            # 1 means to suppress larch_server screen messages, 0 means allow larch_server to print messages
-windows: $pyexe $larchexe
+windows: $larchexec
 END_OF_FILE
 
   open(my $FOUT, '>', $inifile);


### PR DESCRIPTION
This is mostly a change to the way Larch is launched from with Larch.pm, and corresponds to some significant changes to the larch server currently in github master (and should be ready as 0.9.31 by week's end, but there are a few completely unrelated issues to fix).   That is to say, this PR is sort of a placeholder, and a start of the conversation, but should wait for 0.9.31 release to be merged.

This adds a couple functions `test_larch_server()` and `get_next_larch_port()` to test whether a Larch server is running on a port, and to loop through ports and return the first one not in use by Larch server (should find a way to test for "in use by someone else").   These are now used, so that "use Larch;"
will start a new server on the next available port, and use that one (this $port number is now exportable).    The client also sets some client information on the server (PID, username, etc), which can be seen from 
```shell
    larch_server -p 4966 report
```

At the server side, the client is set to automatically expire after some amount of inactivity -- a "keepalive time".   That is, the server records the last time a call to larch() or get_data() happened, and periodically checks if it is time to automatically shutdown.  This is currently set to 7 days (of inactivity).   

It would be helpful if the Demeter clients could stop the server (but of course only the right one!!), either with a 
```perl
$client->shutdown();
``` 
when done, or by setting the keepalive time to a very small number,  perhaps 
```perl
$client->set_keepalive_time(30);
```
to automatically shutdown in 30 seconds.

Also: there are some tweaks here to DemeterBuilder.pm for finding Python/Larch at build time.  But now that I look at all of this again, I wonder if perhaps this should all be moved to Larch.pm and executed at run time.   That would avoid installation hassles on Windows, and would also allow someone to install Larch *after* Demeter. 
