### PR TITLE
Demeter::Data::Prj::Read Add support for access control lists

### DIFF
--- a/lib/Demeter/Data/Prj.pm
+++ b/lib/Demeter/Data/Prj.pm
@@ -30,6 +30,7 @@ use List::MoreUtils qw(any none);
 use Safe;
 
 use Data::Dumper;
+use filetest 'access';
 
 has 'file'    => (is => 'rw', isa => FileName,  default => q{},
 		  trigger => sub{shift -> Read} );


### PR DESCRIPTION
Hi @bruceravel 

I ran into the old Perl file test problem again on our filesystems with ACL permissions... This time when trying to open a project file.

Best,

Tom