### PR TITLE
Athena: properly handle inability to write project file

### DIFF
--- a/lib/Demeter/Data/Athena.pm
+++ b/lib/Demeter/Data/Athena.pm
@@ -28,7 +28,7 @@ sub write_athena {
   my ($self, $filename, @list) = @_;
   croak("You must supply a filename to the write_athena method") if ( (not defined($filename)) or
 								      (ref($filename) =~ m{Data}) );
-  my $gzout = gzopen($filename, 'wb9');
+  my $gzout = gzopen($filename, 'wb9') or croak("$gzerrno");
 
   ##$gzout->gzwrite('$filename = ' . $filename . ";\n\n");
 

--- a/lib/Demeter/UI/Athena/IO.pm
+++ b/lib/Demeter/UI/Athena/IO.pm
@@ -56,7 +56,13 @@ sub Export {
   Demeter->co->set("athena_compatibility" => $app->project_compatibility);
   $app->make_page('Journal') if (not exists $app->{main}->{Journal});
   $app->{main}->{Journal}->{object}->text($app->{main}->{Journal}->{journal}->GetValue);
-  $data[0]->write_athena($fname, @data, $app->{main}->{Journal}->{object});
+  eval {
+    $data[0]->write_athena($fname, @data, $app->{main}->{Journal}->{object});
+  };
+  if ($@) {
+    undef $busy;
+    return $fname;
+  }
   if (dirname($fname) ne Demeter->stash_folder) {
     $data[0]->push_mru("xasdata", $fname);
     $data[0]->push_mru("athena", $fname);


### PR DESCRIPTION
This patch ensures that Athena continues to run whenever a project file
cannot be written to disk, usually because of permissions. A dialog will
now be displayed with an appropriate error message, instead of Athena
terminating.

Reported by Stephen Parry of B18