### PR TITLE
Add dependency for PDL::Filter::Linear - #72

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -105,6 +105,7 @@ my $build = DemeterBuilder
 				'YAML::Tiny'		    => '0',
 
 				'PDL'                       => '2.4.9',
+				'PDL::Filter::Linear'       => '0',
 				#'PDL::Slatec'               => '0',
 				'PDL::Stats'                => '0.5.5',
 


### PR DESCRIPTION
PDL::Filter::Linear was removed from PDL 2.096, and is now on CPAN in an independent distro PDL::Filter.